### PR TITLE
Use lodash.template v3.3.0 as dependency directly

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 'use strict';
 
 var through = require('through2');
-var gutil = require('gulp-util');
+var template = require('lodash.template');
 var extend = require('object-assign');
 
 var headerPlugin = function(headerText, data) {
@@ -10,18 +10,18 @@ var headerPlugin = function(headerText, data) {
 
     var stream = through.obj(function(file, enc, cb) {
 
-        var template = gutil.template(headerText, extend({file : file}, data));
+        var compiled = template(headerText)(extend({file : file}, data));
 
         if (file.isBuffer()) {
             file.contents = Buffer.concat([
-                new Buffer(template),
+                new Buffer(compiled),
                 file.contents
             ]);
         }
 
         if (file.isStream()) {
             var stream = through();
-            stream.write(new Buffer(template));
+            stream.write(new Buffer(compiled));
             stream.on('error', this.emit.bind(this, 'error'));
             file.contents = file.contents.pipe(stream);
         }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "url": "https://github.com/tracker1/gulp-header/issues"
   },
   "dependencies": {
-    "gulp-util": "*",
+    "lodash.template": "^3.3.0",
     "object-assign": "*",
     "through2": "*"
   },

--- a/test/main.js
+++ b/test/main.js
@@ -4,7 +4,6 @@
 
 var header = require('../');
 var should = require('should');
-var gutil = require('gulp-util');
 var fs = require('fs');
 var path = require('path');
 var es = require('event-stream');


### PR DESCRIPTION
Hey the latest gulp-util is v3.0.3 has a newer version of lodash and I think that broke the gulp-header. I changed your dependency to require lodash.template directly and this made the tests pass. 