### PR TITLE
Allow templates to be optionally not called

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,11 @@ module.exports = function (headerText, data) {
       filename = '';
     }
 
-    var template = gutil.template(headerText, extend({file : file}, data));
+    var template = headerText;
+    if (data !== false) {
+      template = gutil.template(headerText, extend({file : file}, data));
+    }
+
     _file = file;
     concat = new Concat(true, filename);
 
@@ -50,13 +54,6 @@ module.exports = function (headerText, data) {
     // add sourcemap
     concat.add(file.relative, file.contents, file.sourceMap);
 
-    // tell the stream engine that we are done with this file
-    cb();
-  }
-
-  function EndStream (cb) {
-    var file = _file.clone({ contents: false });
-
     // make sure streaming content is preserved
     if (file.contents && !isStream(file.contents)) {
       file.contents = concat.content;
@@ -67,12 +64,11 @@ module.exports = function (headerText, data) {
       file.sourceMap = JSON.parse(concat.sourceMap);
     }
 
-    // make sure the file goes through the next gulp plugin
-    this.push(file);
-    cb();
+    // tell the stream engine that we are done with this file
+    cb(null, file);
   }
 
-  return through.obj(TransformStream, EndStream);
+  return through.obj(TransformStream);
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -37,6 +37,11 @@
       "name": "Douglas Duteil",
       "email": "douglasduteil@gmail.com",
       "url": "http://github.com/douglasduteil"
+    },
+    {
+      "name": "James Whitney",
+      "email": "james@whitney.io",
+      "url": "http://github.com/whitneyit"
     }
   ],
   "license": "MIT",


### PR DESCRIPTION
This PR adds the ability to not invoke `gulp.template` if the `data` Object that is passed in is strictly equal to `false`.

On a project I am working on the template files and data Objects are conditionally loaded and parsed. And `gulp-header` started silently failing due to `lodash.template` trying to stamp out data not present in the `data` Object.

This PR also allows the `gulp-template` plugin to stamp out the whole file instead of doing it in two passes.

Thoughts?