### PR TITLE
Fixed dependency version of through2

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "gulp-util": "*",
     "object-assign": "*",
-    "through2": "*",
+    "through2": "^2.0.0",
     "concat-with-sourcemaps": "*"
   },
   "devDependencies": {


### PR DESCRIPTION
Should be using stricter versioning of **through2**, since the convenience method through2.obj was introduced more recently. Addresses issue #29 while using NPM 3. 