### PR TITLE
Filetype filter

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,9 +17,10 @@ var fs = require('fs');
 * gulp-header plugin
 */
 
-module.exports = function (headerText, data) {
+module.exports = function (headerText, data, fileTypes) {
   headerText = headerText || '';
-
+  fileTypes = fileTypes || [];
+  
   function TransformStream(file, enc, cb) {
     var filename;
     var concat;
@@ -43,6 +44,14 @@ module.exports = function (headerText, data) {
       return cb();
     }
 
+    //if filetypes provided, add header only to those files
+    if (fileTypes.length > 0) {
+      if (!fileTypes.includes(filename.split('.')[1])) {
+        this.push(file);
+        // tell the stream engine that we are done with this file
+        return cb();
+      }
+    }
 
     if (file.isBuffer()) {
       concat.add(null, new Buffer(template));

--- a/test/main.js
+++ b/test/main.js
@@ -27,7 +27,7 @@ describe('gulp-header', function() {
   function getFakeFileReadStream(){
     return new File({
       contents: es.readArray(['Hello world']),
-      path: './test/fixture/file2.txt'
+      path: './test/fixture/anotherFile.txt'
     });
   }
 


### PR DESCRIPTION
I added an optional parameter filetypes (array of strings, which are file extensions) which, if provided, adds the header only to files with the provided filetypes (extensions).
Example use case: I use octopus for deployment of .net applications. To create and push packages to octopus, I use gulp. As part of the package creation I need to add the utf-8 bom to vbhtml and cshtml files. I do not want to add the bom to other files in my stream (dll, resx, png, ...)
