### PR TITLE
Modified fs.lstatSync call to make use of fs.existsSync to prevent exceptions

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ module.exports = function (headerText, data) {
     var template = data === false ? headerText : gutil.template(headerText, extend({ file: file, filename: filename }, data));
     concat = new Concat(true, filename);
 
-    if (fs.lstatSync(file.path).isDirectory()) {
+    if (fs.existsSync(file.path) && fs.lstatSync(file.path).isDirectory()) {
       // make sure the file goes through the next gulp plugin
       this.push(file);
 


### PR DESCRIPTION
We discovered this bug this morning and it's been breaking our gulp-angular-templatecache work all day long.  So in the spirit of open source I have submitted a fix for the issue.

Thanks!