### PR TITLE
Fixes undefined template local "filename"

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ module.exports = function (headerText, data) {
 
   function TransformStream(file, enc, cb) {
     // format template
+    var filename = path.basename(file.path);
     var template = data === false ? headerText : gutil.template(headerText, extend({ file: file, filename: filename }, data));
 
     if (file && typeof file === 'string') {
@@ -47,7 +48,6 @@ module.exports = function (headerText, data) {
     }
 
     // variables to handle direct file content manipulation
-    var filename = path.basename(file.path);
     var concat = new Concat(true, filename);
 
     // add template


### PR DESCRIPTION
`filename` was being passed in as a local to the templates but wasn't being set until after its use. Also, there is no explicit documentation surrounding this feature (`file` and `filename` being available as locals), so that's something to think about, too.