### PR TITLE
direct support for gulp-data

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,11 @@ module.exports = function (headerText, data) {
   headerText = headerText || '';
 
   function TransformStream(file, enc, cb) {
+    // direct support for gulp-data
+    if (file.data) {
+      data = extend(file.data, data);
+    }
+
     // format template
     var template = data === false ? headerText : gutil.template(headerText, extend({ file: file, filename: filename }, data));
 
@@ -34,7 +39,6 @@ module.exports = function (headerText, data) {
       this.push(file);
       return cb();
     }
-
 
     // handle file stream;
     if (file.isStream()) {


### PR DESCRIPTION
Merge `file.data` to internal `data` object before template generation, for (_better_) support of [`gulp-data`](https://www.npmjs.com/package/gulp-data).

Details about the change can be found [here](https://www.npmjs.com/package/gulp-data#note-to-gulp-plugin-authors).