### PR TITLE
Drop dependency on deprecated `gulp-util`

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@
 var Concat = require('concat-with-sourcemaps');
 var extend = require('object-assign');
 var through = require('through2');
-var gutil = require('gulp-util');
+var lodashTemplate = require('lodash.template');
 var stream = require('stream');
 var path = require('path');
 var fs = require('fs');
@@ -28,7 +28,7 @@ module.exports = function (headerText, data) {
 
     // format template
     var filename = path.basename(file.path);
-    var template = data === false ? headerText : gutil.template(headerText, extend({ file: file, filename: filename }, data));
+    var template = data === false ? headerText : lodashTemplate(headerText)(extend({ file: file, filename: filename }, data));
 
     if (file && typeof file === 'string') {
       this.push(template + file);

--- a/package.json
+++ b/package.json
@@ -44,10 +44,10 @@
     "url": "https://github.com/tracker1/gulp-header/issues"
   },
   "dependencies": {
-    "gulp-util": "*",
+    "concat-with-sourcemaps": "*",
+    "lodash.template": "^4.4.0",
     "object-assign": "*",
-    "through2": "^2.0.0",
-    "concat-with-sourcemaps": "*"
+    "through2": "^2.0.0"
   },
   "devDependencies": {
     "event-stream": "^3.1.7",

--- a/test/main.js
+++ b/test/main.js
@@ -4,7 +4,6 @@
 
 var header = require('../');
 var should = require('should');
-var gutil = require('gulp-util');
 var fs = require('fs');
 var path = require('path');
 var es = require('event-stream');

--- a/test/main.js
+++ b/test/main.js
@@ -7,6 +7,7 @@ var should = require('should');
 var fs = require('fs');
 var path = require('path');
 var es = require('event-stream');
+var stream = require('stream');
 var File = require('vinyl');
 var gulp = require('gulp');
 require('mocha');
@@ -25,7 +26,7 @@ describe('gulp-header', function() {
 
   function getFakeFileReadStream(){
     return new File({
-      contents: es.readArray(['Hello world']),
+      contents: new stream.Readable({objectMode: true}).wrap(es.readArray(['Hello world'])),
       path: './test/fixture/anotherFile.txt'
     });
   }
@@ -44,7 +45,7 @@ describe('gulp-header', function() {
         should.exist(newFile.path);
         should.exist(newFile.relative);
         should.exist(newFile.contents);
-        newFile.path.should.equal('./test/fixture/file.txt');
+        newFile.path.should.equal('test/fixture/file.txt');
         newFile.relative.should.equal('file.txt');
         newFile.contents.toString('utf8').should.equal('Hello world');
         ++file_count;
@@ -120,7 +121,7 @@ describe('gulp-header', function() {
         ''].join('\n'));
       stream.on('data', function (newFile) {
         should.exist(newFile.contents);
-        newFile.contents.toString('utf8').should.equal('file.txt\n./test/fixture/file.txt\nHello world');
+        newFile.contents.toString('utf8').should.equal('file.txt\ntest/fixture/file.txt\nHello world');
       });
       stream.once('end', done);
 


### PR DESCRIPTION
Closes #54 