### PR TITLE
Update js to es6 and verify with jshint

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,30 +1,26 @@
-/* jshint node: true */
-'use strict';
-
 /**
  * Module dependencies.
  */
 
-var Concat = require('concat-with-sourcemaps');
-var through = require('through2');
-var lodashTemplate = require('lodash.template');
-var stream = require('stream');
-var path = require('path');
-var fs = require('fs');
+const Concat = require('concat-with-sourcemaps');
+const through = require('through2');
+const lodashTemplate = require('lodash.template');
+const stream = require('stream');
+const path = require('path');
 
 /**
  * gulp-header plugin
  */
 
-module.exports = function(headerText, data) {
+module.exports = (headerText, data) => {
   headerText = headerText || '';
 
   function TransformStream(file, enc, cb) {
     // format template
-    var filename = path.basename(file.path);
-    var template =
-      data === false
-        ? headerText
+    const filename = path.basename(file.path);
+    const template =
+      data === false ?
+        headerText
         : lodashTemplate(headerText)(
             Object.assign({}, file.data || {}, { file: file, filename: filename }, data)
           );
@@ -42,7 +38,7 @@ module.exports = function(headerText, data) {
 
     // handle file stream;
     if (file.isStream()) {
-      var stream = through();
+      const stream = through();
       stream.write(Buffer.from(template));
       stream.on('error', this.emit.bind(this, 'error'));
       file.contents = file.contents.pipe(stream);
@@ -51,7 +47,7 @@ module.exports = function(headerText, data) {
     }
 
     // variables to handle direct file content manipulation
-    var concat = new Concat(true, filename);
+    const concat = new Concat(true, filename);
 
     // add template
     concat.add(null, Buffer.from(template));
@@ -82,14 +78,14 @@ module.exports = function(headerText, data) {
 /**
  * is stream?
  */
-function isStream(obj) {
+const isStream = (obj) => {
   return obj instanceof stream.Stream;
-}
+};
 
 /**
  * Is File, and Exists
  */
-function isExistingFile(file) {
+const isExistingFile = (file) => {
   try {
     if (!(file && typeof file === 'object')) return false;
     if (file.isDirectory()) return false;
@@ -98,4 +94,4 @@ function isExistingFile(file) {
     if (typeof file.contents === 'string') return true;
   } catch (err) {}
   return false;
-}
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -420,6 +420,16 @@
         }
       }
     },
+    "cli": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
+      "integrity": "sha1-IoF1NPJL+klQw01TLUjsvGIbjBQ=",
+      "dev": true,
+      "requires": {
+        "exit": "0.1.2",
+        "glob": "^7.1.1"
+      }
+    },
     "cliui": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
@@ -519,6 +529,15 @@
         "source-map": "^0.6.1"
       }
     },
+    "console-browserify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+      "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+      "dev": true,
+      "requires": {
+        "date-now": "^0.1.4"
+      }
+    },
     "convert-source-map": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
@@ -557,6 +576,12 @@
       "requires": {
         "es5-ext": "^0.10.9"
       }
+    },
+    "date-now": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+      "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
+      "dev": true
     },
     "debug": {
       "version": "2.6.9",
@@ -664,6 +689,49 @@
       "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
       "dev": true
     },
+    "dom-serializer": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
+      "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
+      "dev": true,
+      "requires": {
+        "domelementtype": "^1.3.0",
+        "entities": "^1.1.1"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+          "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
+          "dev": true
+        }
+      }
+    },
+    "domelementtype": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
+      "dev": true
+    },
+    "domhandler": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+      "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1"
+      }
+    },
+    "domutils": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+      "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+      "dev": true,
+      "requires": {
+        "dom-serializer": "0",
+        "domelementtype": "1"
+      }
+    },
     "duplexify": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.1.tgz",
@@ -705,6 +773,12 @@
           }
         }
       }
+    },
+    "entities": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+      "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
+      "dev": true
     },
     "error-ex": {
       "version": "1.3.2",
@@ -763,6 +837,12 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
       "dev": true
     },
     "expand-brackets": {
@@ -1811,6 +1891,45 @@
       "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
       "dev": true
     },
+    "htmlparser2": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+      "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1",
+        "domhandler": "2.3",
+        "domutils": "1.5",
+        "entities": "1.0",
+        "readable-stream": "1.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
+      }
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -2061,6 +2180,22 @@
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
+    "jshint": {
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.10.2.tgz",
+      "integrity": "sha512-e7KZgCSXMJxznE/4WULzybCMNXNAd/bf5TSrvVEq78Q/K8ZwFpmBqQeDtNiHc3l49nV4E/+YeHU/JZjSUIrLAA==",
+      "dev": true,
+      "requires": {
+        "cli": "~1.0.0",
+        "console-browserify": "1.1.x",
+        "exit": "0.1.x",
+        "htmlparser2": "3.8.x",
+        "lodash": "~4.17.11",
+        "minimatch": "~3.0.2",
+        "shelljs": "0.3.x",
+        "strip-json-comments": "1.0.x"
+      }
+    },
     "json-stable-stringify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
@@ -2153,6 +2288,12 @@
         "pinkie-promise": "^2.0.0",
         "strip-bom": "^2.0.0"
       }
+    },
+    "lodash": {
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "dev": true
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
@@ -2933,6 +3074,12 @@
         }
       }
     },
+    "shelljs": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+      "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
+      "dev": true
+    },
     "should": {
       "version": "13.2.1",
       "resolved": "https://registry.npmjs.org/should/-/should-13.2.1.tgz",
@@ -3246,6 +3393,12 @@
       "requires": {
         "is-utf8": "^0.2.0"
       }
+    },
+    "strip-json-comments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+      "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+      "dev": true
     },
     "sver-compat": {
       "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,16 @@
   "directories": {
     "test": "test"
   },
+  "jshintConfig": {
+    "esversion": 8,
+    "strict": "implied",
+    "undef": true,
+    "unused": true,
+    "mocha": true,
+    "node": true
+  },
   "scripts": {
+    "pretest": "jshint *.js test",
     "test": "mocha --reporter spec",
     "publish-major": "npm version major && git push origin master && git push --tags",
     "publish-minor": "npm version minor && git push origin master && git push --tags",
@@ -51,6 +60,7 @@
   },
   "devDependencies": {
     "gulp": "^4.0.0",
+    "jshint": "*",
     "mocha": "*",
     "should": "*",
     "vinyl": "*"

--- a/test/main.js
+++ b/test/main.js
@@ -1,14 +1,9 @@
-/* jshint node: true */
-/* global describe, it, beforeEach */
-'use strict';
-
-var header = require('../');
-var should = require('should');
-var fs = require('fs');
-var path = require('path');
-var stream = require('stream');
-var File = require('vinyl');
-var gulp = require('gulp');
+const header = require('../');
+const should = require('should');
+const path = require('path');
+const stream = require('stream');
+const File = require('vinyl');
+const gulp = require('gulp');
 require('mocha');
 
 const streamToString = stream =>
@@ -17,17 +12,17 @@ const streamToString = stream =>
       const chunks = [];
       stream.on('data', chunk => chunks.push(chunk));
       stream.on('error', reject);
-      stream.on('end', _ => resolve(Buffer.concat(chunks).toString('utf8')));
+      stream.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
     } catch (err) {
       reject(err);
     }
   });
 
-describe('gulp-header', function() {
-  var fakeFile;
+describe('gulp-header', () => {
+  let fakeFile;
 
-  function getFakeFile(fileContent, data) {
-    var result = new File({
+  const getFakeFile = (fileContent, data) => {
+    const result = new File({
       path: './test/fixture/file.txt',
       cwd: './test/',
       base: './test/fixture/',
@@ -37,10 +32,10 @@ describe('gulp-header', function() {
       result.data = data;
     }
     return result;
-  }
+  };
 
-  function getFakeFileReadStream() {
-    var s = new stream.Readable({ objectMode: true });
+  const getFakeFileReadStream = () => {
+    const s = new stream.Readable({ objectMode: true });
     s._read = () => {};
     s.push('Hello world');
     s.push(null);
@@ -48,17 +43,17 @@ describe('gulp-header', function() {
       contents: s,
       path: './test/fixture/anotherFile.txt',
     });
-  }
+  };
 
-  beforeEach(function() {
+  beforeEach(() => {
     fakeFile = getFakeFile('Hello world');
   });
 
-  describe('header', function() {
-    it('file should pass through', function(done) {
-      var file_count = 0;
-      var stream = header();
-      stream.on('data', function(newFile) {
+  describe('header', () => {
+    it('file should pass through', (done) => {
+      let file_count = 0;
+      const stream = header();
+      stream.on('data', (newFile) => {
         should.exist(newFile);
         should.exist(newFile.path);
         should.exist(newFile.relative);
@@ -69,7 +64,7 @@ describe('gulp-header', function() {
         ++file_count;
       });
 
-      stream.once('end', function() {
+      stream.once('end', () => {
         file_count.should.equal(1);
         done();
       });
@@ -78,13 +73,13 @@ describe('gulp-header', function() {
       stream.end();
     });
 
-    it('should prepend the header to the file content', function(done) {
-      var myHeader = header('And then i said : ');
+    it('should prepend the header to the file content', (done) => {
+      const myHeader = header('And then i said : ');
 
       myHeader.write(fakeFile);
 
-      myHeader.once('data', function(file) {
-        should(file.isBuffer()).ok;
+      myHeader.once('data', (file) => {
+        should(file.isBuffer()).ok();
         should.exist(file.contents);
         file.contents.toString('utf8').should.equal('And then i said : Hello world');
         done();
@@ -92,13 +87,13 @@ describe('gulp-header', function() {
       myHeader.end();
     });
 
-    it('should prepend the header to the file content (stream)', function(done) {
-      var myHeader = header('And then i said : ');
+    it('should prepend the header to the file content (stream)', (done) => {
+      const myHeader = header('And then i said : ');
 
       myHeader.write(getFakeFileReadStream());
 
-      myHeader.once('data', async function(file) {
-        should(file.isStream()).ok;
+      myHeader.once('data', async (file) => {
+        should(file.isStream()).ok();
         const result = await streamToString(file.contents);
         result.should.equal('And then i said : Hello world');
         done();
@@ -106,10 +101,10 @@ describe('gulp-header', function() {
       myHeader.end();
     });
 
-    it('should format the header', function(done) {
-      var stream = header('And then <%= foo %> said : ', { foo: 'you' });
-      //var stream = header('And then ${foo} said : ', { foo : 'you' } );
-      stream.on('data', function(newFile) {
+    it('should format the header', (done) => {
+      const stream = header('And then <%= foo %> said : ', { foo: 'you' });
+      //const stream = header('And then ${foo} said : ', { foo : 'you' } );
+      stream.on('data', (newFile) => {
         should.exist(newFile.contents);
         newFile.contents.toString('utf8').should.equal('And then you said : Hello world');
       });
@@ -119,9 +114,9 @@ describe('gulp-header', function() {
       stream.end();
     });
 
-    it('should format the header (ES6 delimiters)', function(done) {
-      var stream = header('And then ${foo} said : ', { foo: 'you' });
-      stream.on('data', function(newFile) {
+    it('should format the header (ES6 delimiters)', (done) => {
+      const stream = header('And then ${foo} said : ', { foo: 'you' });
+      stream.on('data', (newFile) => {
         should.exist(newFile.contents);
         newFile.contents.toString('utf8').should.equal('And then you said : Hello world');
       });
@@ -131,9 +126,9 @@ describe('gulp-header', function() {
       stream.end();
     });
 
-    it('should access to the current file', function(done) {
-      var stream = header(['<%= file.relative %>', '<%= file.path %>', ''].join('\n'));
-      stream.on('data', function(newFile) {
+    it('should access to the current file', (done) => {
+      const stream = header(['<%= file.relative %>', '<%= file.path %>', ''].join('\n'));
+      stream.on('data', (newFile) => {
         should.exist(newFile.contents);
         newFile.contents
           .toString('utf8')
@@ -145,9 +140,9 @@ describe('gulp-header', function() {
       stream.end();
     });
 
-    it('should access the data of the current file', function(done) {
-      var stream = header('<%= license %>\n');
-      stream.on('data', function(newFile) {
+    it('should access the data of the current file', (done) => {
+      const stream = header('<%= license %>\n');
+      stream.on('data', (newFile) => {
         should.exist(newFile.contents);
         newFile.contents.toString('utf8').should.equal('WTFPL\nHello world');
       });
@@ -157,32 +152,32 @@ describe('gulp-header', function() {
       stream.end();
     });
 
-    it('multiple files should pass through', function(done) {
-      var headerText = 'use strict;',
+    it('multiple files should pass through', (done) => {
+      const headerText = 'use strict;',
         stream = gulp.src('./test/fixture/*.txt').pipe(header(headerText)),
         files = [];
 
       stream.on('error', done);
-      stream.on('data', function(file) {
+      stream.on('data', (file) => {
         file.contents.toString('utf8').should.startWith(headerText);
         files.push(file);
       });
-      stream.on('end', function() {
+      stream.on('end', () => {
         files.length.should.equal(2);
         done();
       });
     });
 
-    it('no files are acceptable', function(done) {
-      var headerText = 'use strict;',
+    it('no files are acceptable', (done) => {
+      const headerText = 'use strict;',
         stream = gulp.src('./test/fixture/*.html').pipe(header(headerText)),
         files = [];
 
       stream.on('error', done);
-      stream.on('data', function(file) {
+      stream.on('data', (file) => {
         files.push(file);
       });
-      stream.on('end', function() {
+      stream.on('end', () => {
         files.length.should.equal(0);
         done();
       });


### PR DESCRIPTION
Upgrades:

- `var` to `const` or `let`
- `function` to `=>`
- Removed **"defined but never used"** variables
- Fixed **should** assert calls to `ok()`
- Added **jshint** as dev dependency